### PR TITLE
ECS Configuration for Audit

### DIFF
--- a/audit-conf/src/main/yaml/auditConfig.yml
+++ b/audit-conf/src/main/yaml/auditConfig.yml
@@ -49,7 +49,6 @@ audit-info-docker: &docker
     queueSleepMs: "5000"
     queueCapacity: "10"
     sizeChecksumBuffer: 32000000
-
     
   state:
     id: audit
@@ -62,7 +61,7 @@ audit-info-docker: &docker
     subject: "Merritt Audit Cleanup"
     from: "uc3staff@ucop.edu"
     to: "NONE"
-    msg: "Merritt Audit Cleanup Stage"
+    msg: "Merritt Audit Cleanup"
 
   fileLogger:
     messageMaximumLevel: 5
@@ -83,17 +82,7 @@ audit-info-docker: &docker
     password: password
     encoding: "characterEncoding=UTF-8&characterSetResults=UTF-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC"
 
-inv-info-docker-dev: 
-  <<: *docker
-
-  db:
-    user: "{!SSM: inv/readwrite/db-user}"
-    password: "{!SSM: inv/readwrite/db-password}"
-    host: "{!SSM: inv/db-host}"
-    name: "{!SSM: inv/db-name}"
-    encoding: "{!SSM: inv/db-encoding !DEFAULT: characterEncoding=UTF-8&characterSetResults=UTF-8}"
-
-inv-ecs: 
+inv-ecs-dev: 
   <<: *docker
 
   db:
@@ -102,3 +91,13 @@ inv-ecs:
     host: "{!SSM: /uc3/mrt/ecs/billing/db-host !DEFAULT: db-container}"
     name: "inv"
     encoding: "characterEncoding=UTF-8&characterSetResults=UTF-8&useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC"   # schema won't load if it's utf8mb4
+
+inv-ecs: 
+  <<: *docker
+
+  db:
+    user: "{!SSM: inv/readwrite/db-user}"
+    password: "{!SSM: inv/readwrite/db-password}"
+    host: "{!SSM: inv/db-host}"
+    name: "{!SSM: inv/db-name}"
+    encoding: "{!SSM: inv/db-encoding !DEFAULT: characterEncoding=UTF-8&characterSetResults=UTF-8}"

--- a/audit-conf/src/main/yaml/auditConfig.yml
+++ b/audit-conf/src/main/yaml/auditConfig.yml
@@ -40,15 +40,24 @@ audit-info:
     name: "{!SSM: inv/db-name}"
     encoding: "{!SSM: inv/db-encoding !DEFAULT: characterEncoding=UTF-8&characterSetResults=UTF-8}"
 
-audit-info-docker: &docker    
+audit-info-docker: &docker
+  # ecs-stg:
+  #   AUDIT_THREAD_POOL: 2
+  #   AUDIT_QUEUE_SLEEP_MS: 60000
+  #   AUDIT_QUEUE_CAPACITY: 248
+  #   AUDIT_SIZE_CHECKSUM_BUFFER: 16000000
+  # ecs-prd:
+  #   AUDIT_THREAD_POOL: 8
+  #   AUDIT_QUEUE_SLEEP_MS: 0
+  #   AUDIT_QUEUE_CAPACITY: 248
   service:
-    threadPool: "1"
+    threadPool: "{!ENV: AUDIT_THREAD_POOL !DEFAULT: 2}"
     nodePath: "yaml:2"
     auditQualify: "NONE"
     intervalDays: "0"
-    queueSleepMs: "5000"
-    queueCapacity: "10"
-    sizeChecksumBuffer: 32000000
+    queueSleepMs: "{!ENV: AUDIT_QUEUE_SLEEP_MS !DEFAULT: 5000}"
+    queueCapacity: "{!ENV: AUDIT_QUEUE_CAPACITY !DEFAULT: 10}"
+    sizeChecksumBuffer: "{!ENV: AUDIT_SIZE_CHECKSUM_BUFFER !DEFAULT: 32000000}"
     
   state:
     id: audit


### PR DESCRIPTION
## Description of Changes

In the docker environment, all settings will be hard-coded in yaml except the database credentials.

By default, ecs-dev, ecs-stg and ecs-prd will use similar config settings.  We can specialize them in the yaml if needed.

The configuration of database credentials for ecs-dev is a special case.

Please review the default docker config values to decide if they will be appropriate for stage and prod.